### PR TITLE
`ctrl-[` to exit insert mode

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.10.2 / 2019-06-24
+
+ * `ctrl [` exits Vim insert mode
+
 ## 0.10.1 / 2018-11-21
 
   * `ctrl i` enters Vim insert mode from Jupyter command mode (#71) Thanks @wmayner

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Shortcuts this extension introduces:
 | Command/Ctrl-2 | Markdown Cell Mode        |
 | Command/Ctrl-3 | Raw Cell Mode             |
 | Shift-Escape   | Leave Vim Mode            |
+| Escape, Ctrl-\[ | Exit Vim Insert Mode      |
 
 ### Jupyter command bindings
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_vim",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Code cell vim bindings",
   "author": "Jacques Kvam",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -460,6 +460,11 @@ function activateCellVim(app: JupyterLab, tracker: INotebookTracker): Promise<vo
             command: 'leave-insert-mode'
         });
         commands.addKeyBinding({
+            selector: '.jp-Notebook.jp-mod-editMode',
+            keys: ['Ctrl ['],
+            command: 'leave-insert-mode'
+        });
+        commands.addKeyBinding({
             selector: '.jp-Notebook:focus',
             keys: ['Ctrl I'],
             command: 'enter-insert-mode'


### PR DESCRIPTION
## References

This is a PR regarding part of #85.   

## Changes

    * Add `ctrl-[` as keybinding to exit insert mode (same as Escape).

    * Update History.md

    * Add Vim command bindings entry for `ctrl-[` in README.

    * Bump version number to v0.10.2.

I hope it was done as it was supposed to be.