### PR TITLE
PARTIAL: Update to jupyter-lab 1.0.

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.10.2 / 2018-10-08
+
+  * Update for JupyterLab 1.0
+
 ## 0.10.1 / 2018-11-21
 
   * `ctrl i` enters Vim insert mode from Jupyter command mode (#71) Thanks @wmayner

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "jupyterlab_vim",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Code cell vim bindings",
   "author": "Jacques Kvam",
   "license": "MIT",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "license": "MIT",
   "homepage": "https://github.com/jwkvam/jupyterlab_vim",
   "bugs": {
     "url": "https://github.com/jwkvam/jupyterlab_vim/issues"
@@ -35,10 +34,10 @@
     "extension": true
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.19.1",
+    "@jupyterlab/application": "^1.0.0",
+    "@jupyterlab/cells": "^1.0.0",
     "@jupyterlab/codemirror": "^0.19.1",
-    "@jupyterlab/cells": "^0.19.1",
-    "@jupyterlab/notebook": "^0.19.1",
+    "@jupyterlab/notebook": "^1.0.0",
     "@phosphor/commands": "^1.6.1",
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/domutils": "^1.1.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as CodeMirror from 'codemirror';
 
 import {
-    JupyterLab, JupyterLabPlugin
+    JupyterLab, JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
 import {
@@ -34,7 +34,7 @@ const IS_MAC = !!navigator.platform.match(/Mac/i);
 /**
  * Initialization data for the jupyterlab_vim extension.
  */
-const extension: JupyterLabPlugin<void> = {
+const extension: JupyterFrontEndPlugin<void> = {
     id: 'jupyterlab_vim',
     autoStart: true,
     activate: activateCellVim,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "moduleResolution": "node",
     "target": "ES5",
     "outDir": "./lib",
-    "lib": ["ES5", "ES2015.Promise", "DOM"],
+    "lib": ["ES5", "DOM", "ES2015"],
     "types": []
   },
   "include": ["src/*"]


### PR DESCRIPTION
I'm not too familiar with jupyter lab extensions, and won't have time to dig in for a bit.  This change is **NOT** complete. It builds but doesn't work. Posting it in hopes it inspires others ;) 

The plugin executes and throws an exception here: 

```
codemirror.js:7726 Uncaught (in promise) TypeError: Cannot read property 'attach' of undefined
    at CodeMirror.<anonymous> (codemirror.js:7726)
    at codemirror.js:3908
    at CodeMirror.setOption (codemirror.js:8219)
    at Object.setOption (editor.js:1097)
    at CodeMirrorEditor.setOption (editor.js:246)
    at VimCell.push.vDQl.VimCell._onActiveCellChanged (index.js:35)
    at new VimCell (index.js:24)
    at index.js:
```

Please finish the following when submitting a pull request:

- [X] Add a line to `History.md` briefly documenting the change.

If this is a release, additionally do the following:

- [X] Bump the package version in `package.json`
- [X] Update the dependencies in `package.json`
- [ ] Run `jlpm install` to update `yarn.lock`

Thanks!
