### PR TITLE
`ctrl-[` exits insert mode

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.11.1 / 2019-10-08
+
+  * `ctrl [` exits Vim insert mode
+
 ## 0.11.0 / 2019-07-13
 
   * Support JupyterLab 1.0.0+

--- a/README.md
+++ b/README.md
@@ -51,30 +51,31 @@ Shortcuts this extension introduces:
 
 ### Vim command bindings
 
-| Chord          | Action                    |
-| -----          | -------                   |
-| Ctrl-O, U      | Undo Cell Action          |
-| -              | Split Cell at Cursor      |
-| Ctrl-O, -      | Split Cell at Cursor      |
-| Ctrl-O, D      | Cut Cell                  |
-| Ctrl-O, Y      | Copy Cell                 |
-| Ctrl-O, P      | Paste Cell                |
-| Ctrl-Shift-J   | Extend Marked Cells Below |
-| Ctrl-Shift-K   | Extend Marked Cells Above |
-| Ctrl-O, O      | Insert Cell Below         |
-| Ctrl-O, Ctrl-O | Insert Cell Above         |
-| Ctrl-J         | Select Cell Below         |
-| Ctrl-K         | Select Cell Above         |
-| Ctrl-O, G      | Select First Cell         |
-| Ctrl-O, Ctrl-G | Select Last Cell          |
-| Ctrl-E         | Move Cell Down            |
-| Ctrl-Y         | Move Cell Up              |
-| Ctrl-O, Z, Z   | Center Cell               |
-| Ctrl-G         | Show Tooltip              |
-| Command/Ctrl-1 | Code Cell Mode            |
-| Command/Ctrl-2 | Markdown Cell Mode        |
-| Command/Ctrl-3 | Raw Cell Mode             |
-| Shift-Escape   | Leave Vim Mode            |
+| Chord           | Action                    |
+| -----           | ------                    |
+| Ctrl-O, U       | Undo Cell Action          |
+| -               | Split Cell at Cursor      |
+| Ctrl-O, -       | Split Cell at Cursor      |
+| Ctrl-O, D       | Cut Cell                  |
+| Ctrl-O, Y       | Copy Cell                 |
+| Ctrl-O, P       | Paste Cell                |
+| Ctrl-Shift-J    | Extend Marked Cells Below |
+| Ctrl-Shift-K    | Extend Marked Cells Above |
+| Ctrl-O, O       | Insert Cell Below         |
+| Ctrl-O, Ctrl-O  | Insert Cell Above         |
+| Ctrl-J          | Select Cell Below         |
+| Ctrl-K          | Select Cell Above         |
+| Ctrl-O, G       | Select First Cell         |
+| Ctrl-O, Ctrl-G  | Select Last Cell          |
+| Ctrl-E          | Move Cell Down            |
+| Ctrl-Y          | Move Cell Up              |
+| Ctrl-O, Z, Z    | Center Cell               |
+| Ctrl-G          | Show Tooltip              |
+| Command/Ctrl-1  | Code Cell Mode            |
+| Command/Ctrl-2  | Markdown Cell Mode        |
+| Command/Ctrl-3  | Raw Cell Mode             |
+| Shift-Escape    | Leave Vim Mode            |
+| Escape, Ctrl-\[ | Exit Vim Insert Mode      |
 
 ### Jupyter command bindings
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab_vim",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Code cell vim bindings",
   "author": "Jacques Kvam",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -477,6 +477,11 @@ function activateCellVim(app: JupyterFrontEnd, tracker: INotebookTracker): Promi
             command: 'leave-insert-mode'
         });
         commands.addKeyBinding({
+            selector: '.jp-Notebook.jp-mod-editMode',
+            keys: ['Ctrl ['],
+            command: 'leave-insert-mode'
+        });
+        commands.addKeyBinding({
             selector: '.jp-Notebook:focus',
             keys: ['Ctrl I'],
             command: 'enter-insert-mode'


### PR DESCRIPTION
Closes #85.

This PR allows using `ctrl-[` to exit insert mode, which was not working on Firefox.

Please finish the following when submitting a pull request:

- [x] Add a line to `History.md` briefly documenting the change.

If this is a release, additionally do the following:

- [x] Bump the package version in `package.json`
- [x] Update the dependencies in `package.json`
- [x] Run `jlpm install` to update `yarn.lock`

Thanks!
