### PR TITLE
Add documentation for ctrl+i keybinding

### DIFF
--- a/History.md
+++ b/History.md
@@ -2,6 +2,10 @@
 
 ## 0.11.0 / 2019-07-13
 
+  * Add `CTRL+I` to keybindings in README (from 0.10.1 update)
+
+## 0.11.0 / 2019-07-13
+
   * Support JupyterLab 1.0.0+
 
 ## 0.10.1 / 2018-11-21

--- a/README.md
+++ b/README.md
@@ -78,20 +78,21 @@ Shortcuts this extension introduces:
 
 ### Jupyter command bindings
 
-| Chord   | Action            |
-| -----   | ------            |
-| G, G    | Select First Cell |
-| Shift-G | Select Last Cell  |
-| D, D    | Delete Cell       |
-| Y, Y    | Yank (Copy) Cell  |
-| P       | Paste Cell        |
-| Shift-P | Paste Cell Above  |
-| O       | Insert Cell       |
-| Shift-O | Insert Cell Above |
-| U       | Undo Cell Action  |
-| Ctrl-E  | Move Cells Down   |
-| Ctrl-Y  | Move Cells Up     |
-| Z, Z    | Center Cell       |
+| Chord   | Action                                  |
+| -----   | ------                                  |
+| G, G    | Select First Cell                       |
+| Shift-G | Select Last Cell                        |
+| D, D    | Delete Cell                             |
+| Y, Y    | Yank (Copy) Cell                        |
+| P       | Paste Cell                              |
+| Shift-P | Paste Cell Above                        |
+| O       | Insert Cell                             |
+| Shift-O | Insert Cell Above                       |
+| U       | Undo Cell Action                        |
+| Ctrl-E  | Move Cells Down                         |
+| Ctrl-Y  | Move Cells Up                           |
+| Z, Z    | Center Cell                             |
+| Ctrl-I  | Leave Jupyter command mode (enter Cell) |
 
 ## Contributing
 


### PR DESCRIPTION
I couldn't figure out how to get back in a cell from Jupyter command mode, until I searched the repo and found the `ctrl+i` change made in the history file. This just puts the keybinding on the front page so new users can find it. 

Please finish the following when submitting a pull request:

- [x] Add a line to `History.md` briefly documenting the change.

If this is a release, additionally do the following:

- [ ] Bump the package version in `package.json`
- [ ] Update the dependencies in `package.json`
- [ ] Run `jlpm install` to update `yarn.lock`

Thanks!
